### PR TITLE
Added background color config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ return {
         buf_modified_symbol = "M",
         -- or use an icon
         -- buf_modified_symbol = "●"
+        background_color = "WinBarNC"
+        -- or use a hex code:
+		-- background_color = "#141415",
+        -- or a different highlight:
+        -- background_color = "Statusline"
         dim_inactive = {
             enabled = false,
             highlight = "WinBarNC",

--- a/lua/winbar/config.lua
+++ b/lua/winbar/config.lua
@@ -5,6 +5,7 @@ local defaults = {
   buf_modified = true,
   buf_modified_symbol = "M",
   dir_levels = 0,
+  background_color = "WinBarNC",
   dim_inactive = {
     enabled = false,
     highlight = "WinBarNC",
@@ -12,8 +13,8 @@ local defaults = {
     name = true,
   },
   filetype_exclude = {
-		"k8s_*",
-		"snacks_*",
+    "k8s_*",
+    "snacks_*",
     "NeogitStatus",
     "NvimTree",
     "Outline",

--- a/lua/winbar/init.lua
+++ b/lua/winbar/init.lua
@@ -132,6 +132,30 @@ function M.setup(options)
     end
   end
 
+  if config.options.background_color then
+    local function resolve_bg_color(color)
+      if color:match("^#%x+$") then
+        return color
+      end
+
+      local hl_id = vim.fn.hlID(color)
+      if hl_id > 0 then
+        local bg = vim.fn.synIDattr(vim.fn.synIDtrans(hl_id), "bg")
+        return (bg and bg ~= "") and bg or nil
+      end
+
+      return nil
+    end
+
+    local final_bg = resolve_bg_color(config.options.background_color)
+    if final_bg then
+      local groups = { "WinBar", "WinBarNC" }
+      for _, group in ipairs(groups) do
+        vim.api.nvim_set_hl(0, group, { bg = final_bg })
+      end
+    end
+  end
+
   M.register()
 end
 


### PR DESCRIPTION
This PR adds the ability to set the background color of the winbar to something else.

I added a config prop called `background_color`. Its default value is `"WinBarNC"` which reflects the default behavior that currently exists. This can be changed to any highlight (e.g., "Statusline") or a hex code (e.g., "#141415"). 

To work within the existing structure of the plugin, when background_color is set (or left default), `"WinBarNC"` and `"WinBar"` are updated to have that customized value. This logic is in `init.lua`