### PR TITLE
Optional function for more complex file exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ return {
         -- the function should return true when you want to exclude the winbar, false otherwise.
         -- for example:
 		-- exclude_if = function()
-        --   local is_magenta_window = vim.w.magenta or false
-		--   return is_magenta_window == true
+		--   return vim.w.magenta == true
         -- end
       })
     end

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ return {
             icons = true, -- whether to dim the icons
             name = true, -- whether to dim the name
         }
+        exclude_if = nil
+        -- define a function that returns a boolean to exclude winbar in specific circumstances.
+        -- the function should return true when you want to exclude the winbar, false otherwise.
+        -- for example:
+		-- exclude_if = function()
+        --   local is_magenta_window = vim.w.magenta or false
+		--   return is_magenta_window == true
+        -- end
       })
     end
   },

--- a/lua/winbar/config.lua
+++ b/lua/winbar/config.lua
@@ -34,6 +34,7 @@ local defaults = {
     "toggleterm",
     "trouble",
   },
+  exclude_if = nil,
 }
 
 M.options = {}

--- a/lua/winbar/init.lua
+++ b/lua/winbar/init.lua
@@ -104,6 +104,18 @@ function M.register()
         end
       end
 
+      if config.options.exclude_if and type(config.options.exclude_if) == "function" then
+        local should_exclude = config.options.exclude_if()
+        if should_exclude then
+          local ok, winbar_set_by_plugin = pcall(vim.api.nvim_buf_get_var, 0, "winbar_set_by_winbar_nvim")
+          if ok and winbar_set_by_plugin then
+            vim.opt_local.winbar = nil
+            vim.api.nvim_buf_set_var(0, "winbar_set_by_winbar_nvim", false)
+          end
+          return
+        end
+      end
+
       local win_number = vim.api.nvim_get_current_win()
       local win_config = vim.api.nvim_win_get_config(win_number)
 


### PR DESCRIPTION
Added a new `exclude_if` configuration option that complements the existing filetype exclusions. This allows users to dynamically control winbar visibility using a function that returns `true` to hide the winbar or `false` to show it.

This is useful when windows have a commonly used filetype that normally *should* have a winbar but which is part of other, non-file, functionality. 

For example, [magenta.nvim](https://github.com/dlants/magenta.nvim) has its own toggleable windows which are essentially heavily modified markdown. Instead of just disabling winbar for all markdowns files, we can target the specific windows we want:

```lua
exclude_if = function()
  return vim.w.magenta == true
end
```

